### PR TITLE
chore: Simplify .gitignore model file exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# Model files - ignore all except specific pre-trained models
-models/*
-!models/space_invaders_dqn_3000000_steps.zip
-!models/pong_dqn_500000_steps.zip
-
 # Ignore other model formats
 *.pkl
 *.h5

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,112 @@
+# Agent Arcade Models
+
+This directory contains model configurations and saved models for different Atari games supported by Agent Arcade.
+
+## Directory Structure
+
+```
+models/
+├── README.md
+├── pong/
+│   ├── config.yaml           # Training configuration
+│   ├── checkpoints/          # Training checkpoints
+│   └── final_model.zip       # Best performing model
+├── space_invaders/
+│   ├── config.yaml           # Training configuration
+│   ├── checkpoints/          # Training checkpoints
+│   └── final_model.zip       # Best performing model
+└── river_raid/
+    ├── config.yaml           # Training configuration
+    ├── checkpoints/          # Training checkpoints
+    └── final_model.zip       # Best performing model
+```
+
+## Game Configurations
+
+### Pong
+- Environment: `ALE/Pong-v5`
+- Training Steps: 1M
+- Expected Score: 15+ points
+- Training Time: ~2 hours on M-series MacBook
+
+### Space Invaders
+- Environment: `ALE/SpaceInvaders-v5`
+- Training Steps: 3M
+- Expected Score: 270+ points
+- Training Time: ~6 hours on M-series MacBook
+- Special Features: Prioritized replay, dueling networks
+
+### River Raid
+- Environment: `ALE/RiverRaid-v5`
+- Training Steps: 2M
+- Custom reward shaping for fuel management
+- Advanced training features enabled
+
+## Usage
+
+1. **Training a Model**:
+   ```bash
+   agent-arcade train pong --config models/pong/config.yaml
+   ```
+
+2. **Evaluating a Model**:
+   ```bash
+   agent-arcade evaluate pong --model models/pong/final_model.zip
+   ```
+
+3. **Competition Entry**:
+   ```bash
+   agent-arcade stake place pong --model models/pong/final_model.zip --amount 10 --target-score 15
+   ```
+
+## Model Checkpoints
+
+Each game directory contains a `checkpoints` folder that stores intermediate models during training. Checkpoints are saved every 100,000 steps and can be used to:
+- Resume training from a specific point
+- Compare performance across training stages
+- Select the best performing model
+
+## Configuration Details
+
+Each `config.yaml` file contains:
+- Training hyperparameters
+- Network architecture settings
+- Preprocessing options
+- Game-specific configurations
+- Visualization settings
+
+## Performance Metrics
+
+Monitor training progress using TensorBoard:
+```bash
+tensorboard --logdir ./tensorboard
+```
+
+Key metrics to watch:
+- Episode rewards
+- Loss values
+- Exploration rate
+- Training FPS
+
+## Best Practices
+
+1. **Start with Default Configs**:
+   - Use provided configurations as starting points
+   - They're optimized for M-series MacBooks
+   - Adjust based on your hardware
+
+2. **Incremental Training**:
+   - Start with 250K steps to verify setup
+   - Increase to full training once stable
+   - Save checkpoints frequently
+
+3. **Model Selection**:
+   - Evaluate models over multiple episodes
+   - Consider both mean score and consistency
+   - Test against competition requirements
+
+4. **Hardware Optimization**:
+   - CPU: Use 4+ cores
+   - RAM: 8GB minimum
+   - GPU: Optional but recommended
+   - Storage: 1GB for models 

--- a/models/pong/config.yaml
+++ b/models/pong/config.yaml
@@ -1,0 +1,34 @@
+algo: "DQN"
+env: "ALE/Pong-v5"
+total_timesteps: 1000000
+learning_rate: 0.00025
+buffer_size: 500000
+learning_starts: 100000
+batch_size: 256
+exploration_fraction: 0.4
+exploration_final_eps: 0.01
+train_log_interval: 100
+
+# Network optimization
+gamma: 0.99
+target_update_interval: 1000
+gradient_steps: 4
+train_freq: 4
+frame_stack: 16
+
+# Preprocessing
+scale_rewards: true
+normalize_frames: true
+terminal_on_life_loss: true
+
+# Visualization
+viz_interval: 25000
+video_interval: 100000
+video_length: 400
+checkpoint_interval: 100000
+demo_mode: false
+
+# Model architecture
+policy: "CnnPolicy"
+features_extractor: "NatureCNN"
+features_dim: 512 

--- a/models/river_raid/config.yaml
+++ b/models/river_raid/config.yaml
@@ -1,0 +1,49 @@
+algo: "DQN"
+env: "ALE/RiverRaid-v5"
+total_timesteps: 2000000  # Balanced for complexity
+learning_rate: 0.00025
+buffer_size: 500000
+learning_starts: 100000
+batch_size: 256
+exploration_fraction: 0.4
+exploration_final_eps: 0.01
+train_log_interval: 100
+
+# Network optimization
+gamma: 0.99
+target_update_interval: 1000
+gradient_steps: 4
+train_freq: 4
+frame_stack: 16
+
+# Preprocessing
+scale_rewards: true
+normalize_frames: true
+terminal_on_life_loss: true
+
+# Visualization
+viz_interval: 25000
+video_interval: 100000
+video_length: 400
+checkpoint_interval: 100000
+demo_mode: false
+
+# Model architecture
+policy: "CnnPolicy"
+features_extractor: "NatureCNN"
+features_dim: 512
+
+# Advanced training options
+prioritized_replay: true
+alpha: 0.6
+beta0: 0.4
+dueling: true
+double_q: true
+max_grad_norm: 10
+
+# Game-specific settings
+# River Raid requires careful fuel management and has complex scoring
+reward_shaping:
+  fuel_bonus: 1.0
+  score_multiplier: 1.0
+  death_penalty: -1.0 

--- a/models/space_invaders/config.yaml
+++ b/models/space_invaders/config.yaml
@@ -1,0 +1,46 @@
+algo: "DQN"
+env: "ALE/SpaceInvaders-v5"
+total_timesteps: 3000000  # Increased for better performance
+learning_rate: 0.00025
+buffer_size: 500000
+learning_starts: 100000
+batch_size: 256
+exploration_fraction: 0.4
+exploration_final_eps: 0.01
+train_log_interval: 100
+
+# Network optimization
+gamma: 0.99
+target_update_interval: 1000
+gradient_steps: 4
+train_freq: 4
+frame_stack: 16
+
+# Preprocessing
+scale_rewards: true
+normalize_frames: true
+terminal_on_life_loss: true
+
+# Game specific settings
+difficulty: 0
+mode: 0
+
+# Visualization
+viz_interval: 25000
+video_interval: 100000
+video_length: 400
+checkpoint_interval: 100000
+demo_mode: false
+
+# Model architecture
+policy: "CnnPolicy"
+features_extractor: "NatureCNN"
+features_dim: 512
+
+# Advanced training options
+prioritized_replay: true
+alpha: 0.6
+beta0: 0.4
+dueling: true
+double_q: true
+max_grad_norm: 10 


### PR DESCRIPTION
This pull request introduces updates to the `models` directory, including the addition of a new `README.md` file and detailed configuration files for various Atari games supported by Agent Arcade. The changes aim to provide clear guidance on model training, evaluation, and usage.

Documentation and Structure:

* [`models/README.md`](diffhunk://#diff-1d83aff5f1fdb552508d5ab9735c4760be0f14f54bc2bb058506ad5e8698fe18R1-R112): Added a new README file that outlines the directory structure, game configurations, usage instructions, and best practices for training models.

Configuration Files:

* [`models/pong/config.yaml`](diffhunk://#diff-88e181bdb4f66414521dbe41656e102082ff4aada6a1a0e79d9a0360a03e55fcR1-R34): Introduced a configuration file for training the Pong model using the DQN algorithm, including hyperparameters, preprocessing options, and visualization settings.
* [`models/river_raid/config.yaml`](diffhunk://#diff-867a83e188401a2a0b4b3118ab173056bfdca0a71ff0000b1b4fdc6338cbba89R1-R49): Added a configuration file for training the River Raid model with advanced training options such as prioritized replay and custom reward shaping.
* [`models/space_invaders/config.yaml`](diffhunk://#diff-fe6d99a3479285b540f0304174350022ee72519d5208e579937995b1446d55f5R1-R46): Created a configuration file for training the Space Invaders model, incorporating advanced features like dueling networks and prioritized replay.